### PR TITLE
Tweaks to config

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -30,22 +30,25 @@
               "required": true
             },
             "NormallyClosed": {
-            "type": "boolean",
-            "title": "Normally Closed Switch",
-            "default": false,
-            "description": "Check to make the switch normally-closed (on). Default is normally-open (off)."
+              "type": "boolean",
+              "title": "Normally On Switch",
+              "default": false,
+              "description": "Check to make the switch normally-closed (on). Default is normally-open (off)."
             },
             "SwitchStayOn": {
               "type": "boolean",
               "title": "Stateful",
               "default": false,
-              "description": "Check to make the switch stateful (remain on after trigger)."
+              "description": "Check to make the switch stateful (disable timer)."
             },
             "Time": {
               "type": "integer",
-              "title": "Auto Off Time (in ms)",
+              "title": "Timer (in ms)",
               "default": 5000,
-               "description": "Duration in milliseconds that the switch stays on after triggering. Only relevant if the switch is not stateful."
+              "description": "Duration in milliseconds that the switch stays after triggering. Only relevant if the switch is not stateful.",
+              "condition": {
+                "functionBody": "return model.devices[arrayIndices[0]].SwitchStayOn === false;"
+              }
             },
             "UseLogFile": {
               "type": "boolean",
@@ -57,15 +60,18 @@
               "type": "string",
               "title": "Log File Path",
               "default": "/var/lib/homebridge/homebridge.log",
-              "description": "Enter the full path to the log file."
+              "description": "Enter the full path to the log file.",
+              "condition": {
+                "functionBody": "return model.devices[arrayIndices[0]].UseLogFile === true;"
+              }
             },
             "Keywords": {
-              "type": "array",
+              "type": "string",
               "title": "Keywords",
-              "items": {
-                "type": "string"
-              }, 
-              "description": "Enter keywords/phrases that will trigger the switch when they appear in the log file (case independent)."
+              "description": "Enter comma separated keywords/phrases that will trigger the switch when they appear in the log file (case independent).",
+              "condition": {
+                "functionBody": "return model.devices[arrayIndices[0]].UseLogFile === true;"
+              }
             },
             "EnableStartupDelay": {
               "type": "boolean",
@@ -76,20 +82,67 @@
             "StartupDelay": {
               "type": "integer",
               "title": "Startup Delay (in ms)",
-              "default": 10000,
-              "description": "Time in milliseconds to delay the switch start after Homebridge restarts."
+              "default": 3000,
+              "description": "Time in milliseconds to delay the switch start after Homebridge restarts.",
+              "condition": {
+                "functionBody": "return model.devices[arrayIndices[0]].EnableStartupDelay === true;"
+              }
             },
-            "RememberState" : {
+            "RememberState": {
               "type": "boolean",
-              "title" : "Restart in last known state",
-              "default" : false,
-              "description" : "Switch will restart in its last known state (only for non-log-monitoring stateful switches)."
+              "title": "Restart in last known state",
+              "default": false,
+              "description": "Switch will restart in its last known state (only for non-log-monitoring stateful switches)."
             }
           },
-          "required": ["Name"]
+          "required": [
+            "Name"
+          ]
         }
       }
     },
-    "required": ["name","platform", "devices"]
-  }
+    "required": [
+      "name",
+      "platform",
+      "devices"
+    ]
+  },
+  "layout": [
+    {
+      "type": "fieldset",
+      "title": "General",
+      "description": "",
+      "expandable": true,
+      "expanded": false,
+      "items": [
+        "name"
+      ]
+    },
+    {
+      "type": "array",
+      "key": "devices",
+      "title": "Devices",
+      "description": "",
+      "buttonText": "Add",
+      "expandable": true,
+      "expanded": true,
+      "items": [
+        {
+          "type": "fieldset",
+          "items": [
+            "devices[].Name",
+            "devices[].Time",
+            "devices[].SwitchStayOn",
+            "devices[].NormallyClosed",
+            "devices[].UseLogFile",
+            "devices[].LogFilePath",
+            "devices[].Keywords",
+            "devices[].EnableStartupDelay",
+            "devices[].StartupDelay",
+            "devices[].RememberState"
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/config.schema.json
+++ b/config.schema.json
@@ -9,13 +9,14 @@
         "title": "Name",
         "type": "string",
         "required": true,
-        "default": "HomebridgeVirtualSwitches"
+        "default": "HomebridgeVirtualSwitches",
+        "description": "This name will be displayed as child bridge name and in logs."
       },
       "platform": {
         "type": "string",
         "title": "Platform Name",
         "default": "HomebridgeVirtualSwitches",
-        "description": "Do not change Name, nor Platform name!"
+        "description": "Do not change Platform name!"
       },
       "devices": {
         "type": "array",
@@ -108,16 +109,7 @@
     ]
   },
   "layout": [
-    {
-      "type": "fieldset",
-      "title": "General",
-      "description": "",
-      "expandable": true,
-      "expanded": false,
-      "items": [
-        "name"
-      ]
-    },
+    
     {
       "type": "array",
       "key": "devices",
@@ -142,6 +134,16 @@
             "devices[].RememberState"
           ]
         }
+      ]
+    },
+    {
+      "type": "fieldset",
+      "title": "Plugin config",
+      "description": "",
+      "expandable": true,
+      "expanded": false,
+      "items": [
+        "name"
       ]
     }
   ]


### PR DESCRIPTION
### changes:
- auto show / hide some fields if they are not needed, E.G.: hide timer if Statuful is checked, hide log path if logs not enabled.
- changed field keywords from array to string (if you accept this PR you need to fix function to split string to array of objects)
- hide Platform Name because user should not change this field

### what is missing for me? 
- option to activate / trigger switch after Homebridge start
- option to select timer units (minutes, seconds, hours, days)
- please merge these two logs 'Switch "Test" turned on' and /Switch "Test" will turn off after 5000 milliseconds.' into one, eg.: 'Switch "Test" turned on, it will turn off after 5000 milliseconds.'.


<img width="797" alt="Zrzut ekranu 2024-10-3 o 12 10 02" src="https://github.com/user-attachments/assets/112b4e10-87d7-4ece-9213-acbd9fdb7d22">
